### PR TITLE
Add delivery options 'generic' and 'custom'

### DIFF
--- a/lib/deliveries.js
+++ b/lib/deliveries.js
@@ -6,7 +6,7 @@ module.exports = {
   //delivery for email js
   emailjs : function(options) {
     //load the email library from the parent path
-    var email = require(options.path); 
+    var email = require(options.path);
     var smtp  = email.server.connect(options.config.server);
 
     return function(tokenToSend, uidToSend, recipient, callback, req) {
@@ -16,27 +16,67 @@ module.exports = {
         tokenToSend : tokenToSend,
         uidToSend   : uidToSend,
         recipient   : recipient,
-        req         : req 
+        req         : req
       };
 
       try {
         var email = {
           text    : _.template(msg.text)(dataObj),
-          from    : msg.from ? _.template(msg.to)(dataObj) : options.config.server.user, 
+          from    : msg.from ? _.template(msg.to)(dataObj) : options.config.server.user,
           to      : msg.to ? _.template(msg.to)(dataObj) : uidToSend,
           subject : _.template(msg.subject)(dataObj)
         };
 
         if (msg.html) {
           email.attachment = [
-            { 
-              data : _.template(msg.html)(dataObj), 
-              alternative:true 
+            {
+              data : _.template(msg.html)(dataObj),
+              alternative:true
             }
           ];
         }
 
-        smtp.send(email, function(err, message) { 
+        smtp.send(email, function(err, message) {
+          callback(err);
+        });
+      } catch(err) {
+        callback('Error while sending mail : ' + err);
+      }
+    }
+  },
+
+  generic : function(options) {
+    //load the email library from the parent path
+    var mailer_function = options.mailer_function;
+
+    return function(tokenToSend, uidToSend, recipient, callback, req) {
+      var msg     = options.config.msg;
+      var dataObj = {
+        hostName    : helper.getBaseUrl(req.headers.referer),
+        tokenToSend : tokenToSend,
+        uidToSend   : uidToSend,
+        recipient   : recipient,
+        req         : req
+      };
+
+      try {
+        var email_args = {
+          text    : _.template(msg.text)(dataObj),
+          from    : msg.from ? _.template(msg.to)(dataObj) : options.config.server.user,
+          to      : msg.to ? _.template(msg.to)(dataObj) : uidToSend,
+          subject : _.template(msg.subject)(dataObj)
+        };
+
+        if (msg.html) {
+          email_args.attachment = [
+            {
+              data : _.template(msg.html)(dataObj),
+              alternative:true
+            }
+          ];
+        }
+
+        mailer_function(email_args, function(err, message) {
           callback(err);
         });
       } catch(err) {

--- a/lib/deliveries.js
+++ b/lib/deliveries.js
@@ -80,5 +80,9 @@ module.exports = {
         callback('Error while sending mail : ' + err);
       }
     }
+  },
+
+  custom : function(options) {
+    return options.mailer_function;
   }
 };

--- a/lib/deliveries.js
+++ b/lib/deliveries.js
@@ -60,20 +60,17 @@ module.exports = {
       };
 
       try {
-        var email_args = {
-          text    : _.template(msg.text)(dataObj),
-          from    : msg.from ? _.template(msg.to)(dataObj) : options.config.server.user,
-          to      : msg.to ? _.template(msg.to)(dataObj) : uidToSend,
-          subject : _.template(msg.subject)(dataObj)
-        };
+        var email = msg;
+        email.from = msg.from ? _.template(msg.from)(dataObj) : options.config.server.user;
+        email.to = msg.to ? _.template(msg.to)(dataObj) : uidToSend;
+        email.subject = _.template(msg.subject)(dataObj);
 
         if (msg.html) {
-          email_args.attachment = [
-            {
-              data : _.template(msg.html)(dataObj),
-              alternative:true
-            }
-          ];
+          email_args.html = _.template(msg.html)(dataObj);
+        }
+
+        if (msg.text) {
+          email_args.text = _.template(msg.text)(dataObj);
         }
 
         mailer_function(email_args, function(err, message) {

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -34,7 +34,7 @@ PasswordlessStrategy.prototype.checkOptions = function() {
 
   //check if the store was set or if an allready existing passwordless store was applied
   if (!this.options.store.initialized) {
-    if (!this.options.store.config) { 
+    if (!this.options.store.config) {
       throw new Error('Store parameter is missing! Please specify a passwordless datastore parameters!');
     }
 
@@ -56,14 +56,14 @@ PasswordlessStrategy.prototype.checkOptions = function() {
 
   //check for a valid delivery (a function or a described object for predefined ones)
   if (!this.options.delivery || (!util.isFunction(this.options.delivery) && (!this.options.delivery.type || !deliveries[this.options.delivery.type]))) {
-    throw new Error('Delivery parameter is missing or invalid! Please specify a valid delivery! ' + 
-                    'The delivery must be a functions or one of the following specified deliveries + : ' + 
+    throw new Error('Delivery parameter is missing or invalid! Please specify a valid delivery! ' +
+                    'The delivery must be a functions or one of the following specified deliveries + : ' +
                     Object.keys(deliveries).join(', '));
   }
 
   //check if the delivery is not a function and set it with the predefined function
   if (!util.isFunction(this.options.delivery)) {
-    this.options.delivery = deliveries[this.options.delivery.type](this.options.delivery); 
+    this.options.delivery = deliveries[this.options.delivery.type](this.options.delivery);
   }
 
   if (!util.isFunction(this.options.access)) {
@@ -84,7 +84,7 @@ PasswordlessStrategy.prototype.initPasswordless = function() {
     allowTokenReuse : !!this.options.allowTokenReuse
   });
 
-  
+
   //initialize the delivery
   var that = this;
   this.passwordless.addDelivery(this.options.delivery, {
@@ -108,8 +108,9 @@ PasswordlessStrategy.prototype.authenticate = function(req, options) {
 
   //get request parameters to check the authentication state
   var user  = this.getParam(req.query, this.options.userField,  'user');
+  if (!user) { user = this.getParam(req.body, this.options.userField,  'user'); }
   var token = this.getParam(req.query, this.options.tokenField, 'token');
-  var uid   = this.getParam(req.query, this.options.uidField,   'uid'); 
+  var uid   = this.getParam(req.query, this.options.uidField,   'uid');
 
   //if a token and a uid was specified, verify the token
   //if only a user was specified, generate a token and send it


### PR DESCRIPTION
Two option added: `generic` and `custom`
- `generic` takes a `mailer_function` option that holds reference to a JS function that takes an object (with params) and a callback
- `custom` offloads the task of retrieving and constructing the email to the user, but allows greater flexibility for templating